### PR TITLE
エラーメッセージの日本語化

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -91,3 +91,4 @@ gem 'pry-rails'
 gem 'payjp'
 gem 'gon'
 gem "aws-sdk-s3", require: false
+gem 'rails-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -229,6 +229,9 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
+    rails-i18n (7.0.7)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (7.0.6)
       actionpack (= 7.0.6)
       activesupport (= 7.0.6)
@@ -354,6 +357,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 5.0)
   rails (~> 7.0.0)
+  rails-i18n
   rspec-rails (~> 4.0.0)
   rubocop
   selenium-webdriver

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -44,5 +44,4 @@ class OrdersController < ApplicationController
   def valid
     gon.public_key = ENV['PAYJP_PUBLIC_KEY']
   end
-
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -14,10 +14,12 @@ class Item < ApplicationRecord
   with_options presence: true do
     validates :image, :name, :description
 
-    with_options numericality: { other_than: 1 } do
+    with_options numericality: { other_than: 1, message: 'を入力してください' } do
       validates :category_id, :status_id, :shipping_cost_id, :prefecture_id, :shipping_day_id
     end
 
-    validates :price, numericality: { only_integer: true, greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999 }
+    validates :price,
+              numericality: { only_integer: true, greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999,
+                              message: 'を ¥300〜9,999,999以内で入力してください' }
   end
 end

--- a/app/models/order_shipping.rb
+++ b/app/models/order_shipping.rb
@@ -8,11 +8,11 @@ class OrderShipping
     validates :item_id
     validates :token
 
-    validates :postcode, format: { with: /\A[0-9]{3}-[0-9]{4}\z/, message: 'is invalid. Enter it as follows (e.g. 123-4567)' }
-    validates :prefecture_id, numericality: { other_than: 1, message: "can't be blank" }
+    validates :postcode, format: { with: /\A[0-9]{3}-[0-9]{4}\z/, message: 'を入力してください (例)123-4567' }
+    validates :prefecture_id, numericality: { other_than: 1, message: "を入力して下さい" }
     validates :city
     validates :block
-    validates :phone_number, format: { with: /\A\d{10,11}\z/, message: 'is invalid. Input only number' }
+    validates :phone_number, format: { with: /\A\d{10,11}\z/, message: 'は数値のみを入力してください' }
   end
 
   def save

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,12 +12,12 @@ class User < ApplicationRecord
     validates :birthday
 
     PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i
-    validates_format_of :password, with: PASSWORD_REGEX, message: 'is invalid. Include both letters and numbers'
+    validates_format_of :password, with: PASSWORD_REGEX, message: 'は6文字以上の半角英数字で入力してください'
 
-    validates :last_name, format: { with: /\A[ぁ-んァ-ヶ一-龥々ー]+\z/, message: 'Input full-width characters' }
-    validates :first_name, format: { with: /\A[ぁ-んァ-ヶ一-龥々ー]+\z/, message: 'Input full-width characters' }
-    validates :last_name_kana, format: { with: /\A[ァ-ヶー－]+\z/, message: 'Input full-width katakana characters' }
-    validates :first_name_kana, format: { with: /\A[ァ-ヶー－]+\z/, message: 'Input full-width katakana characters' }
+    validates :last_name, format: { with: /\A[ぁ-んァ-ヶ一-龥々ー]+\z/ }
+    validates :first_name, format: { with: /\A[ぁ-んァ-ヶ一-龥々ー]+\z/ }
+    validates :last_name_kana, format: { with: /\A[ァ-ヶー－]+\z/ }
+    validates :first_name_kana, format: { with: /\A[ァ-ヶー－]+\z/ }
   end
 end
 # email, passwordは、deviseにデフォルトで設定済みのため未記入

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,6 +12,9 @@ module Furima39575
     config.load_defaults 7.0
     config.active_storage.variant_processor = :mini_magick
 
+    # 日本語の言語設定
+    config.i18n.default_locale = :ja
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,150 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        nickname: ニックネーム
+        birthday: 誕生日
+        last_name: 名字(全角)
+        first_name: 名前(全角)
+        last_name_kana: 名字(カナ)
+        first_name_kana: 名前(カナ)
+        confirmation_sent_at: パスワード確認送信時刻
+        confirmation_token: パスワード確認用トークン
+        confirmed_at: パスワード確認時刻
+        created_at: 作成日
+        current_password: 現在のパスワード
+        current_sign_in_at: 現在のログイン時刻
+        current_sign_in_ip: 現在のログインIPアドレス
+        email: Eメール
+        encrypted_password: 暗号化パスワード
+        failed_attempts: 失敗したログイン試行回数
+        last_sign_in_at: 最終ログイン時刻
+        last_sign_in_ip: 最終ログインIPアドレス
+        locked_at: ロック時刻
+        password: パスワード
+        password_confirmation: パスワード（確認用）
+        remember_created_at: ログイン記憶時刻
+        remember_me: ログインを記憶する
+        reset_password_sent_at: パスワードリセット送信時刻
+        reset_password_token: パスワードリセット用トークン
+        sign_in_count: ログイン回数
+        unconfirmed_email: 未確認Eメール
+        unlock_token: ロック解除用トークン
+        updated_at: 更新日
+    models:
+      user: ユーザー
+  devise:
+    confirmations:
+      confirmed: メールアドレスが確認できました。
+      new:
+        resend_confirmation_instructions: アカウント確認メール再送
+      send_instructions: アカウントの有効化について数分以内にメールでご連絡します。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。
+    failure:
+      already_authenticated: すでにログインしています。
+      inactive: アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。
+      invalid: "%{authentication_keys}またはパスワードが違います。"
+      last_attempt: もう一回誤るとアカウントがロックされます。
+      locked: アカウントはロックされています。
+      not_found_in_database: "%{authentication_keys}またはパスワードが違います。"
+      timeout: セッションがタイムアウトしました。もう一度ログインしてください。
+      unauthenticated: ログインもしくはアカウント登録してください。
+      unconfirmed: メールアドレスの本人確認が必要です。
+    mailer:
+      confirmation_instructions:
+        action: メールアドレスの確認
+        greeting: "%{recipient}様"
+        instruction: 以下のリンクをクリックし、メールアドレスの確認手続を完了させてください。
+        subject: メールアドレス確認メール
+      email_changed:
+        greeting: こんにちは、%{recipient}様。
+        message: メールアドレスの（%{email}）変更が完了したため、メールを送信しています。
+        message_unconfirmed: メールアドレスが（%{email}）変更されたため、メールを送信しています。
+        subject: メール変更完了
+      password_change:
+        greeting: "%{recipient}様"
+        message: パスワードが再設定されました。
+        subject: パスワードの変更について
+      reset_password_instructions:
+        action: パスワード変更
+        greeting: "%{recipient}様"
+        instruction: パスワード再設定の依頼を受けたため、メールを送信しています。下のリンクからパスワードの再設定ができます。
+        instruction_2: パスワード再設定の依頼をしていない場合、このメールを無視してください。
+        instruction_3: パスワードの再設定は、上のリンクから新しいパスワードを登録するまで完了しません。
+        subject: パスワードの再設定について
+      unlock_instructions:
+        action: アカウントのロック解除
+        greeting: "%{recipient}様"
+        instruction: アカウントのロックを解除するには下のリンクをクリックしてください。
+        message: ログイン失敗が繰り返されたため、アカウントはロックされています。
+        subject: アカウントのロック解除について
+    omniauth_callbacks:
+      failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
+      success: "%{kind} アカウントによる認証に成功しました。"
+    passwords:
+      edit:
+        change_my_password: パスワードを変更する
+        change_your_password: パスワードを変更
+        confirm_new_password: 確認用新しいパスワード
+        new_password: 新しいパスワード
+      new:
+        forgot_your_password: パスワードを忘れましたか？
+        send_me_reset_password_instructions: パスワードの再設定方法を送信する
+      no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
+      send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。
+      updated: パスワードが正しく変更されました。
+      updated_not_active: パスワードが正しく変更されました。
+    registrations:
+      destroyed: アカウントを削除しました。またのご利用をお待ちしております。
+      edit:
+        are_you_sure: 本当によろしいですか？
+        cancel_my_account: アカウント削除
+        currently_waiting_confirmation_for_email: "%{email} の確認待ち"
+        leave_blank_if_you_don_t_want_to_change_it: 空欄のままなら変更しません
+        title: "%{resource}編集"
+        unhappy: 気に入りません
+        update: 更新
+        we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください
+      new:
+        sign_up: アカウント登録
+      signed_up: アカウント登録が完了しました。
+      signed_up_but_inactive: ログインするためには、アカウントを有効化してください。
+      signed_up_but_locked: アカウントがロックされているためログインできません。
+      signed_up_but_unconfirmed: 本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。
+      update_needs_confirmation: アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。
+      updated: アカウント情報を変更しました。
+      updated_but_not_signed_in: あなたのアカウントは正常に更新されましたが、パスワードが変更されたため、再度ログインしてください。
+    sessions:
+      already_signed_out: 既にログアウト済みです。
+      new:
+        sign_in: ログイン
+      signed_in: ログインしました。
+      signed_out: ログアウトしました。
+    shared:
+      links:
+        back: 戻る
+        didn_t_receive_confirmation_instructions: アカウント確認のメールを受け取っていませんか？
+        didn_t_receive_unlock_instructions: アカウントのロック解除方法のメールを受け取っていませんか？
+        forgot_your_password: パスワードを忘れましたか？
+        sign_in: ログイン
+        sign_in_with_provider: "%{provider}でログイン"
+        sign_up: アカウント登録
+      minimum_password_length: "（%{count}字以上）"
+    unlocks:
+      new:
+        resend_unlock_instructions: アカウントのロック解除方法を再送する
+      send_instructions: アカウントのロック解除方法を数分以内にメールでご連絡します。
+      send_paranoid_instructions: アカウントが見つかった場合、アカウントのロック解除方法を数分以内にメールでご連絡します。
+      unlocked: アカウントをロック解除しました。
+  errors:
+    messages:
+      already_confirmed: は既に登録済みです。ログインしてください。
+      confirmation_period_expired: の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。
+      expired: の有効期限が切れました。新しくリクエストしてください。
+      not_found: は見つかりませんでした。
+      not_locked: はロックされていません。
+      not_saved:
+        one: エラーが発生したため %{resource} は保存されませんでした。
+        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"
+  

--- a/config/locales/item.ja.yml
+++ b/config/locales/item.ja.yml
@@ -1,0 +1,17 @@
+ja:
+  activerecord:
+    attributes:
+      item:
+        image: "商品画像"
+        name: "商品名"
+        description: "商品の説明"
+        category_id: "カテゴリ"
+        status_id: "商品の詳細"
+        shipping_cost_id: "配送料の負担"
+        prefecture_id: "発送元の地域"
+        shipping_day_id: "発送までの日数"
+        price: "価格"
+  errors:
+    messages:
+      blank: "を入力してください"
+  

--- a/config/locales/order_shipping.ja.yml
+++ b/config/locales/order_shipping.ja.yml
@@ -1,0 +1,10 @@
+ja:
+    activemodel:
+        attributes:
+            order_shipping:
+                postcode: 郵便番号
+                city: 市区町村
+                block: 番地
+                phone_number: 電話番号
+                prefecture_id: 都道府県名
+                token: クレジットカード情報

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -15,87 +15,87 @@ RSpec.describe Item, type: :model do
       it '画像が空欄' do
         @item.image = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("Image can't be blank")
+        expect(@item.errors.full_messages).to include('商品画像を入力してください')
       end
       it '商品名が空欄' do
         @item.name = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include("Name can't be blank")
+        expect(@item.errors.full_messages).to include('商品名を入力してください')
       end
       it '商品の説明が空欄' do
         @item.description = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include("Description can't be blank")
+        expect(@item.errors.full_messages).to include('商品の説明を入力してください')
       end
       it '商品のカテゴリが空欄' do
         @item.category_id = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("Category can't be blank")
+        expect(@item.errors.full_messages).to include('カテゴリを入力してください')
       end
       it '商品の状態が空欄' do
         @item.status_id = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("Status can't be blank")
+        expect(@item.errors.full_messages).to include('商品の詳細を入力してください')
       end
       it '配送料の負担が空欄' do
         @item.shipping_cost_id = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("Shipping cost can't be blank")
+        expect(@item.errors.full_messages).to include('配送料の負担を入力してください')
       end
       it '発送元の地域が空欄' do
         @item.prefecture_id = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("Prefecture can't be blank")
+        expect(@item.errors.full_messages).to include('発送元の地域を入力してください')
       end
       it '発送までの日数が空欄' do
         @item.shipping_day_id = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("Shipping day can't be blank")
+        expect(@item.errors.full_messages).to include('発送までの日数を入力してください')
       end
       it '価格が空欄' do
         @item.price = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price can't be blank")
+        expect(@item.errors.full_messages).to include('価格を入力してください')
       end
       it '価格が300円より低い' do
         @item.price = '299'
         @item.valid?
-        expect(@item.errors.full_messages).to include('Price must be greater than or equal to 300')
+        expect(@item.errors.full_messages).to include('価格を ¥300〜9,999,999以内で入力してください')
       end
       it '価格が9,999,999円より高い' do
         @item.price = '10000000'
         @item.valid?
-        expect(@item.errors.full_messages).to include('Price must be less than or equal to 9999999')
+        expect(@item.errors.full_messages).to include('価格を ¥300〜9,999,999以内で入力してください')
       end
       it '価格が半角数値のみではない' do
         @item.price = '１1２2'
         @item.valid?
-        expect(@item.errors.full_messages).to include('Price is not a number')
+        expect(@item.errors.full_messages).to include('価格を ¥300〜9,999,999以内で入力してください')
       end
       it 'カテゴリーの項目が[---]のとき' do
         @item.category_id = '1'
         @item.valid?
-        expect(@item.errors.full_messages).to include('Category must be other than 1')
+        expect(@item.errors.full_messages).to include('カテゴリを入力してください')
       end
       it '商品の状態の項目が[---]のとき' do
         @item.status_id = '1'
         @item.valid?
-        expect(@item.errors.full_messages).to include('Status must be other than 1')
+        expect(@item.errors.full_messages).to include('商品の詳細を入力してください')
       end
       it '配送料の負担の項目が[---]のとき' do
         @item.shipping_cost_id = '1'
         @item.valid?
-        expect(@item.errors.full_messages).to include('Shipping cost must be other than 1')
+        expect(@item.errors.full_messages).to include('配送料の負担を入力してください')
       end
       it '発送元の地域の項目が[---]のとき' do
         @item.prefecture_id = '1'
         @item.valid?
-        expect(@item.errors.full_messages).to include('Prefecture must be other than 1')
+        expect(@item.errors.full_messages).to include('発送元の地域を入力してください')
       end
       it '発送までの日数の項目が[---]のとき' do
         @item.shipping_day_id = '1'
         @item.valid?
-        expect(@item.errors.full_messages).to include('Shipping day must be other than 1')
+        expect(@item.errors.full_messages).to include('発送までの日数を入力してください')
       end
       it 'ユーザー情報が空欄のとき' do
         @item.user_id = nil

--- a/spec/models/order_shipping.rb
+++ b/spec/models/order_shipping.rb
@@ -30,82 +30,82 @@ RSpec.describe OrderShipping, type: :model do
       it 'user_idが空欄' do
         @order_shipping.user_id = nil
         @order_shipping.valid?
-        expect(@order_shipping.errors.full_messages).to include("User can't be blank")
+        expect(@order_shipping.errors.full_messages).to include
       end
       it 'item_idが空欄' do
         @order_shipping.item_id = nil
         @order_shipping.valid?
-        expect(@order_shipping.errors.full_messages).to include("Item can't be blank")
+        expect(@order_shipping.errors.full_messages).to include
       end
       it '郵便番号が空欄' do
         @order_shipping.postcode = ''
         @order_shipping.valid?
-        expect(@order_shipping.errors.full_messages).to include("Postcode can't be blank")
+        expect(@order_shipping.errors.full_messages).to include('郵便番号を入力してください (例)123-4567')
       end
       it '郵便番号にハイフンが含まれていない' do
         @order_shipping.postcode = '1234567'
         @order_shipping.valid?
-        expect(@order_shipping.errors.full_messages).to include('Postcode is invalid. Enter it as follows (e.g. 123-4567)')
+        expect(@order_shipping.errors.full_messages).to include('郵便番号を入力してください (例)123-4567')
       end
       it '郵便番号が「3桁ハイフン4桁」の半角文字列ではない(1234-5678)' do
         @order_shipping.postcode = '1234-5678'
         @order_shipping.valid?
-        expect(@order_shipping.errors.full_messages).to include('Postcode is invalid. Enter it as follows (e.g. 123-4567)')
+        expect(@order_shipping.errors.full_messages).to include('郵便番号を入力してください (例)123-4567')
       end
       it '郵便番号が「3桁ハイフン4桁」の半角文字列ではない(123-567)' do
         @order_shipping.postcode = '123-567'
         @order_shipping.valid?
-        expect(@order_shipping.errors.full_messages).to include('Postcode is invalid. Enter it as follows (e.g. 123-4567)')
+        expect(@order_shipping.errors.full_messages).to include('郵便番号を入力してください (例)123-4567')
       end
       it '郵便番号が半角文字列ではない(全角の場合)' do
         @order_shipping.postcode = '１２３-４５６７'
         @order_shipping.valid?
-        expect(@order_shipping.errors.full_messages).to include('Postcode is invalid. Enter it as follows (e.g. 123-4567)')
+        expect(@order_shipping.errors.full_messages).to include('郵便番号を入力してください (例)123-4567')
       end
       it '都道府県の項目が[---]のとき' do
         @order_shipping.prefecture_id = 1
         @order_shipping.valid?
-        expect(@order_shipping.errors.full_messages).to include("Prefecture can't be blank")
+        expect(@order_shipping.errors.full_messages).to include('都道府県名を入力して下さい')
       end
       it '市区町村が空欄' do
         @order_shipping.city = ''
         @order_shipping.valid?
-        expect(@order_shipping.errors.full_messages).to include("City can't be blank")
+        expect(@order_shipping.errors.full_messages).to include('市区町村を入力してください')
       end
       it '番地が空欄' do
         @order_shipping.block = ''
         @order_shipping.valid?
-        expect(@order_shipping.errors.full_messages).to include("Block can't be blank")
+        expect(@order_shipping.errors.full_messages).to include('番地を入力してください')
       end
       it '電話番号が空欄' do
         @order_shipping.phone_number = ''
         @order_shipping.valid?
-        expect(@order_shipping.errors.full_messages).to include('Phone number is invalid. Input only number')
+        expect(@order_shipping.errors.full_messages).to include('電話番号を入力してください')
       end
       it '電話番号が9桁以下(9桁の場合)' do
         @order_shipping.phone_number = '123456789'
         @order_shipping.valid?
-        expect(@order_shipping.errors.full_messages).to include('Phone number is invalid. Input only number')
+        expect(@order_shipping.errors.full_messages).to include('電話番号は数値のみを入力してください')
       end
       it '電話番号が12桁以上(12桁の場合)' do
         @order_shipping.phone_number = '123456789012'
         @order_shipping.valid?
-        expect(@order_shipping.errors.full_messages).to include('Phone number is invalid. Input only number')
+        expect(@order_shipping.errors.full_messages).to include('電話番号は数値のみを入力してください')
       end
       it '電話番号にハイフンが含まれる' do
         @order_shipping.phone_number = '029-777-777'
         @order_shipping.valid?
-        expect(@order_shipping.errors.full_messages).to include('Phone number is invalid. Input only number')
+        expect(@order_shipping.errors.full_messages).to include('電話番号は数値のみを入力してください')
       end
       it '電話番号が半角文字列ではない(全角の場合)' do
         @order_shipping.phone_number = '１２３４５６７８９０１'
         @order_shipping.valid?
-        expect(@order_shipping.errors.full_messages).to include('Phone number is invalid. Input only number')
+        expect(@order_shipping.errors.full_messages).to include('電話番号は数値のみを入力してください')
       end
       it 'トークンが空欄' do
         @order_shipping.token = ''
         @order_shipping.valid?
-        expect(@order_shipping.errors.full_messages).to include("Token can't be blank")
+        expect(@order_shipping.errors.full_messages).to include('クレジットカード情報を入力してください')
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -47,103 +47,103 @@ RSpec.describe User, type: :model do
       it 'ニックネームが空欄' do
         @user.nickname = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Nickname can't be blank")
+        expect(@user.errors.full_messages).to include('ニックネームを入力してください')
       end
       it '名前（全角）が空欄' do
         @user.first_name = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("First name can't be blank")
+        expect(@user.errors.full_messages).to include('名前(全角)を入力してください')
       end
       it '名字（全角）が空欄' do
         @user.last_name = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Last name can't be blank")
+        expect(@user.errors.full_messages).to include('名字(全角)を入力してください')
       end
       it '名前（フリガナ）が空欄' do
         @user.first_name_kana = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("First name kana can't be blank")
+        expect(@user.errors.full_messages).to include('名前(カナ)を入力してください')
       end
       it '名字（フリガナ）が空欄' do
         @user.last_name_kana = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Last name kana can't be blank")
+        expect(@user.errors.full_messages).to include('名字(カナ)を入力してください')
       end
       it '名前が全角（漢字・ひらがな・カタカナ）ではない' do
         @user.first_name = 'dai'
         @user.valid?
-        expect(@user.errors.full_messages).to include('First name Input full-width characters')
+        expect(@user.errors.full_messages).to include('名前(全角)は不正な値です')
       end
       it '名字が全角（漢字・ひらがな・カタカナ）ではない' do
         @user.last_name = 'yama'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Last name Input full-width characters')
+        expect(@user.errors.full_messages).to include('名字(全角)は不正な値です')
       end
       it '名前のフリガナが全角（カタカナ）ではない' do
         @user.first_name_kana = '大'
         @user.valid?
-        expect(@user.errors.full_messages).to include('First name kana Input full-width katakana characters')
+        expect(@user.errors.full_messages).to include('名前(カナ)は不正な値です')
       end
       it '名字のフリガナが全角（カタカナ）ではない' do
         @user.last_name_kana = '山'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Last name kana Input full-width katakana characters')
+        expect(@user.errors.full_messages).to include('名字(カナ)は不正な値です')
       end
       it '生年月日が空欄' do
         @user.birthday = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Birthday can't be blank")
+        expect(@user.errors.full_messages).to include('誕生日を入力してください')
       end
       it 'メールアドレスが空欄' do
         @user.email = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Email can't be blank")
+        expect(@user.errors.full_messages).to include('Eメールを入力してください')
       end
       it 'パスワードが空欄' do
         @user.password = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password can't be blank")
+        expect(@user.errors.full_messages).to include('パスワードを入力してください')
       end
       it 'パスワード（確認）が空欄' do
         @user.password = 'a12345'
         @user.password_confirmation = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password")
+        expect(@user.errors.full_messages).to include('パスワード（確認用）とパスワードの入力が一致しません')
       end
       it 'パスワードが半角数字のみ' do
         @user.password = '123456'
         @user.password_confirmation = '123456'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Password is invalid. Include both letters and numbers')
+        expect(@user.errors.full_messages).to include('パスワードは6文字以上の半角英数字で入力してください')
       end
       it 'パスワードが6文字以上ではない' do
         @user.password = 'a1234'
         @user.password_confirmation = 'a1234'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Password is too short (minimum is 6 characters)')
+        expect(@user.errors.full_messages).to include('パスワードは6文字以上で入力してください')
       end
       it 'パスワードが半角英字のみ' do
         @user.password = 'abcdef'
         @user.password_confirmation = 'abcdef'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Password is invalid. Include both letters and numbers')
+        expect(@user.errors.full_messages).to include('パスワードは6文字以上の半角英数字で入力してください')
       end
       it 'パスワードに全角文字が含まれる' do
         @user.password = 'Abcdef'
         @user.password_confirmation = 'Abcdef'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Password is invalid. Include both letters and numbers')
+        expect(@user.errors.full_messages).to include('パスワードは6文字以上の半角英数字で入力してください')
       end
       it '重複したemailが存在する' do
         @user.save
         another_user = FactoryBot.build(:user, email: @user.email)
         another_user.valid?
-        expect(another_user.errors.full_messages).to include('Email has already been taken')
+        expect(another_user.errors.full_messages).to include('Eメールはすでに存在します')
       end
       it 'emailに@が含まれない' do
         @user.email = 'abcdef'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Email is invalid')
+        expect(@user.errors.full_messages).to include('Eメールは不正な値です')
       end
     end
   end


### PR DESCRIPTION
# what
エラーメッセージを英語から日本語に変更
# why
日本人向けのアプリのため日本語表記の方がわかりやすい